### PR TITLE
New component for handing mobile view logic

### DIFF
--- a/client/src/store/actions/globalActions.spec.ts
+++ b/client/src/store/actions/globalActions.spec.ts
@@ -1,18 +1,36 @@
 import {
   setNeedsResize,
+  setShouldResize,
   mobileDetect,
+  setHasResized,
 } from './globalActions';
 import {
-  SET_NEEDS_RESIZE,
   SET_IS_MOBILE,
+  SET_NEEDS_RESIZE,
+  SET_SHOULD_RESIZE,
+  SET_HAS_RESIZED,
 } from '../constants';
 
 describe('Global Actions', () => {
-  it('should create an action to increase our resize counter', () => {
+  it('should create an action for SET_NEEDS_RESIZE', () => {
     const expectedAction = {
       type: SET_NEEDS_RESIZE,
     };
     expect(setNeedsResize()).toEqual(expectedAction);
+  });
+
+  it('should create an action for SET_SHOULD_RESIZE', () => {
+    const expectedAction = {
+      type: SET_SHOULD_RESIZE,
+    };
+    expect(setShouldResize()).toEqual(expectedAction);
+  });
+
+  it('should create an action for SET_HAS_RESIZED', () => {
+    const expectedAction = {
+      type: SET_HAS_RESIZED,
+    };
+    expect(setHasResized()).toEqual(expectedAction);
   });
 
   it('should create an action to set our moible boolean', () => {

--- a/client/src/store/actions/globalActions.ts
+++ b/client/src/store/actions/globalActions.ts
@@ -4,6 +4,18 @@ export function setNeedsResize() {
   };
 };
 
+export function setShouldResize() {
+  return {
+    type: 'SET_SHOULD_RESIZE',
+  };
+};
+
+export function setHasResized() {
+  return {
+    type: 'SET_HAS_RESIZED',
+  };
+};
+
 export function mobileDetect(isMobile: boolean) {
   return {
     type: 'SET_IS_MOBILE',

--- a/client/src/store/constants/index.ts
+++ b/client/src/store/constants/index.ts
@@ -1,5 +1,9 @@
 export const RECEIVE_ROOM_ID = 'RECEIVE_ROOM_ID';
 export const LEAVE_ROOM = 'LEAVE_ROOM';
 export const SET_CURRENT_ROOM = 'SET_CURRENT_ROOM';
+
 export const SET_NEEDS_RESIZE = 'SET_NEEDS_RESIZE';
+export const SET_SHOULD_RESIZE = 'SET_SHOULD_RESIZE';
+export const SET_HAS_RESIZED = 'SET_HAS_RESIZED';
+
 export const SET_IS_MOBILE = 'SET_IS_MOBILE';

--- a/client/src/store/reducers/globalReducer.spec.ts
+++ b/client/src/store/reducers/globalReducer.spec.ts
@@ -2,10 +2,14 @@ import reducer from './globalReducer';
 import {
   SET_IS_MOBILE,
   SET_NEEDS_RESIZE,
+  SET_SHOULD_RESIZE,
+  SET_HAS_RESIZED,
 } from '../constants';
 
 const defaultState = {
   needsResize: 0,
+  shouldResize: 0,
+  hasResized: 0,
   isMobile: false,
 };
 
@@ -18,6 +22,8 @@ describe('Global Reducer', () => {
     ).toEqual(
       {
         needsResize: 1,
+        shouldResize: 0,
+        hasResized: 0,
         isMobile: false,
       }
     );
@@ -25,6 +31,8 @@ describe('Global Reducer', () => {
     expect(
       reducer({
         needsResize: 1,
+        shouldResize: 0,
+        hasResized: 0,
         isMobile: false,
       }, {
         type: SET_NEEDS_RESIZE,
@@ -32,11 +40,78 @@ describe('Global Reducer', () => {
     ).toEqual(
       {
         needsResize: 2,
+        shouldResize: 0,
+        hasResized: 0,
         isMobile: false,
       }
     );
   });
 
+  it('should handle SET_SHOULD_RESIZE', () => {
+    expect(
+      reducer(defaultState, {
+        type: SET_SHOULD_RESIZE,
+      })
+    ).toEqual(
+      {
+        needsResize: 0,
+        shouldResize: 1,
+        hasResized: 0,
+        isMobile: false,
+      }
+    );
+
+    expect(
+      reducer({
+        needsResize: 1,
+        shouldResize: 1,
+        hasResized: 0,
+        isMobile: false,
+      }, {
+        type: SET_SHOULD_RESIZE,
+      })
+    ).toEqual(
+      {
+        needsResize: 1,
+        shouldResize: 2,
+        hasResized: 0,
+        isMobile: false,
+      }
+    );
+  });
+
+  it('should handle SET_HAS_RESIZED', () => {
+    expect(
+      reducer(defaultState, {
+        type: SET_HAS_RESIZED,
+      })
+    ).toEqual(
+      {
+        needsResize: 0,
+        shouldResize: 0,
+        hasResized: 1,
+        isMobile: false,
+      }
+    );
+
+    expect(
+      reducer({
+        needsResize: 1,
+        shouldResize: 1,
+        hasResized: 0,
+        isMobile: false,
+      }, {
+        type: SET_HAS_RESIZED,
+      })
+    ).toEqual(
+      {
+        needsResize: 1,
+        shouldResize: 1,
+        hasResized: 1,
+        isMobile: false,
+      }
+    );
+  });
   it('should handle SET_IS_MOBILE', () => {
     expect(
       reducer(defaultState, {
@@ -46,6 +121,8 @@ describe('Global Reducer', () => {
     ).toEqual(
       {
         needsResize: 0,
+        shouldResize: 0,
+        hasResized: 0,
         isMobile: false,
       }
     );
@@ -53,6 +130,8 @@ describe('Global Reducer', () => {
     expect(
       reducer({
         needsResize: 1,
+        shouldResize: 0,
+        hasResized: 0,
         isMobile: false,
       }, {
         type: SET_IS_MOBILE,
@@ -61,6 +140,8 @@ describe('Global Reducer', () => {
     ).toEqual(
       {
         needsResize: 1,
+        shouldResize: 0,
+        hasResized: 0,
         isMobile: true,
       }
     );

--- a/client/src/store/reducers/globalReducer.ts
+++ b/client/src/store/reducers/globalReducer.ts
@@ -1,9 +1,11 @@
 interface globalAction  {
-  type: 'SET_NEEDS_RESIZE' | 'SET_IS_MOBILE',
+  type: 'SET_NEEDS_RESIZE' | 'SET_SHOULD_RESIZE' | 'SET_HAS_RESIZED' | 'SET_IS_MOBILE',
   isMobile?: boolean,
 }
 export default function reducer(state = {
   needsResize: 0,
+  shouldResize: 0,
+  hasResized: 0,
   isMobile: false,
 }, action: globalAction) {
   switch (action.type) {
@@ -25,6 +27,18 @@ export default function reducer(state = {
         ...state,
         needsResize: state.needsResize + 1,
       };
+    }
+    case 'SET_SHOULD_RESIZE' : {
+      return {
+        ...state,
+        shouldResize: state.shouldResize + 1,
+      }
+    }
+    case 'SET_HAS_RESIZED' : {
+      return {
+        ...state,
+        hasResized: state.hasResized + 1,
+      }
     }
     case 'SET_IS_MOBILE': {
       return {

--- a/client/src/view/App.tsx
+++ b/client/src/view/App.tsx
@@ -12,16 +12,11 @@ import Home from './components/homepage/Home';
 import Room from './components/chat/Room';
 import { HasAddedToRoom } from './components/lib/events/rooms';
 import { addRoomID, setCurrentRoom } from 'store/actions/roomActions';
-import {
-  setNeedsResize,
-  mobileDetect,
-} from 'store/actions/globalActions';
-import { MobileCheck } from './components/lib/helpers/windowEvents';
+import MobileViewUtility from './components/lib/helpers/MobileViewUtility';
 
 const App = () => {
   const [addedToRoom, roomID] = HasAddedToRoom();
-  const [smallScreen] = MobileCheck();
-  const { needsResize, isMobile } = useSelector((state: any) => state.global);
+  const { needsResize, shouldResize } = useSelector((state: any) => state.global);
   const [mobileStyle, setMobileStyle] = useState({});
   const dispatch = useDispatch();
 
@@ -31,21 +26,20 @@ const App = () => {
   }, [dispatch, roomID, addedToRoom]);
 
   useEffect(() => {
-    if (smallScreen) {
-      dispatch(mobileDetect(true));
-      dispatch(setNeedsResize());
-    } else {
-      dispatch(mobileDetect(false));
-    }
-  }, [dispatch, smallScreen]);
-
-  useEffect(() => {
-    if (needsResize && isMobile) {
+    /**
+     * Should set the height any time we've determined
+     * it's ready to update AND on the initial setResize.
+     * Initial set means we've loaded on a mobile device
+     * and that's about it. Perhaps switching this for
+     * something that's more clear would be a better
+     * approach.
+     */
+    if (shouldResize || needsResize === 1) {
       setMobileStyle({
         height: window.innerHeight + 'px',
       });
     }
-  }, [needsResize, isMobile]);
+  }, [shouldResize, needsResize]);
 
   return (
     <div
@@ -61,6 +55,7 @@ const App = () => {
           useAnimation={ false }
         />
       </div>
+      <MobileViewUtility />
     </div>
   );
 };

--- a/client/src/view/components/chat/Chat.spec.tsx
+++ b/client/src/view/components/chat/Chat.spec.tsx
@@ -16,13 +16,19 @@ jest.mock('socket.io-client', () => {
 
 Enzyme.configure({ adapter: new Adapter() });
 let useSelectorSpy: any;
+let useDispatchSpy: any;
 
 describe('Chat wrapper', () => {
   beforeEach(() => {
+    useDispatchSpy = jest.spyOn(Redux, 'useDispatch');
+    useDispatchSpy.mockReturnValue(jest.fn());
+
     useSelectorSpy = jest.spyOn(Redux, 'useSelector');
     const initialState = {
       isMobile: false,
-      needsResize: false,
+      needsResize: 0,
+      shouldResize: 0,
+      hasResized: 0,
     };
     useSelectorSpy.mockReturnValue(initialState);
   });

--- a/client/src/view/components/chat/Chat.tsx
+++ b/client/src/view/components/chat/Chat.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
 } from 'react';
 import {
+  useDispatch,
   useSelector,
 } from 'react-redux';
 import { Paper } from '@material-ui/core';
@@ -10,6 +11,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Feed from './Feed';
 import MessageForm from './form/Form';
 import TypingAlert from './TypingAlert';
+import { setHasResized } from 'store/actions/globalActions';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -22,14 +24,18 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Chat = () => {
-  const { needsResize, isMobile } = useSelector((state: any) => state.global);
+  const dispatch = useDispatch();
+  const { shouldResize } = useSelector((state: any) => state.global);
   const [mobileStyle, setMobileStyle] = useState({});
 
   useEffect(() => {
-    if (needsResize && isMobile) setMobileStyle({
-      height: window.innerHeight + 'px',
-    });
-  }, [needsResize, isMobile]);
+    if (shouldResize) {
+      setMobileStyle({
+        height: window.innerHeight + 'px',
+      });
+      dispatch(setHasResized());
+    }
+  }, [shouldResize, dispatch]);
 
   const classes = useStyles();
   return (

--- a/client/src/view/components/chat/Feed.spec.tsx
+++ b/client/src/view/components/chat/Feed.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Redux from 'react-redux';
 import io, { Socket } from 'socket.io-client';
 import { mount } from 'enzyme';
 import Feed from './Feed';
@@ -14,8 +15,19 @@ jest.mock('socket.io-client', () => {
 
 const mockedIO = io as jest.Mocked<typeof io>;
 const mockedSocket = mockedIO() as jest.Mocked<typeof Socket>;
+let useSelectorSpy: any;
 
 describe('Feed', () => {
+  beforeEach(() => {
+    useSelectorSpy = jest.spyOn(Redux, 'useSelector');
+    const initialState = {
+      isMobile: false,
+      needsResize: 0,
+      shouldResize: 0,
+      hasResided: 0,
+    };
+    useSelectorSpy.mockReturnValue(initialState);
+  });
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/client/src/view/components/chat/Feed.tsx
+++ b/client/src/view/components/chat/Feed.tsx
@@ -9,6 +9,7 @@ import ChatMessage from 'view/components/lib/events/chatMessage';
 import { UserJoined, UserLeft } from 'view/components/lib/events/lifeCycle';
 import UserMessage from './messages/UserMessage';
 import StatusMessage from './messages/StatusMessage';
+import { useSelector } from 'react-redux';
 
 const useStyles = makeStyles((theme) => (
   {
@@ -24,6 +25,7 @@ const useStyles = makeStyles((theme) => (
 
 const Feed = () => {
   const classes = useStyles();
+  const { hasResized } = useSelector((state: any) => state.global);
   const [messages, setMessages] = useState<Messages>([]);
   const [newMessage] = ChatMessage();
   const [userHasJoined] = UserJoined();
@@ -77,12 +79,12 @@ const Feed = () => {
       }
     };
 
-    if (messages) {
+    if (messages || hasResized) {
       handleScroll();
 
       // Could append additional logic here for when feed is updated.
     }
-  }, [messages]);
+  }, [messages, hasResized]);
 
   const messageBody = (message: ChatMessage | StatusUpdate, index: number) => {
     if (message.messageType === 'message') {

--- a/client/src/view/components/lib/helpers/MobileViewUtility.tsx
+++ b/client/src/view/components/lib/helpers/MobileViewUtility.tsx
@@ -1,0 +1,73 @@
+import React, {
+  useEffect,
+} from 'react';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
+import { MobileCheck } from './windowEvents';
+import {
+  setNeedsResize,
+  setShouldResize,
+  mobileDetect,
+} from 'store/actions/globalActions';
+
+const MobileViewUtility = () => {
+  const [smallScreen] = MobileCheck();
+  const { needsResize, isMobile } = useSelector((state: any) => state.global);
+
+  const dispatch = useDispatch();
+  /**
+   * On load we'll check if mobile and run an initial resizing if so.
+   */
+  useEffect(() => {
+    if (smallScreen) {
+      dispatch(mobileDetect(true));
+      dispatch(setNeedsResize());
+    } else {
+      dispatch(mobileDetect(false));
+    }
+  }, [dispatch, smallScreen]);
+
+  /**
+   * This should check to make sure we're only resizing
+   * content when the page has actually changed.
+   *
+   * There can be timing discrepencies between when the
+   * resizing is called and when the actual browser window
+   * has changed. For example, setting the new height as
+   * soon as a form has focus will set the height BEFORE
+   * the mobile keyboard is active.
+   *
+   * Definitely open to doing this a different way, but don't
+   * think there's any great way to determine when mobile
+   * keyboards are open or not.
+   */
+  useEffect(() => {
+    if (needsResize && isMobile) {
+      let iterationCount = 0;
+      let prevHeight = window.innerHeight;
+      let heightCheckInterval: NodeJS.Timeout;
+
+      heightCheckInterval = setInterval(() => {
+        const currentHeight = window.innerHeight;
+        // if we've run this 50 times then stop
+        if (iterationCount >= 50) clearInterval(heightCheckInterval);
+
+        // If change detected than resize with our new height
+        if (currentHeight !== prevHeight) {
+          dispatch(setShouldResize());
+          clearInterval(heightCheckInterval);
+        } else {
+          // Can just increment our counter and keep prevHeight as is
+          iterationCount++;
+        }
+      }, 10);
+    }
+  }, [needsResize, isMobile, dispatch]);
+  return (
+    <>
+    </>
+  );
+}
+export default MobileViewUtility;


### PR DESCRIPTION
Adds new state variables for our resizing logic to track when a resize should happen and after one has happened. Hopefully now we'll have better control over knowing when the window view has actually changed.

Moved some previous logic outside of our base app component and into a new one to be more DRY.