### PR TITLE
Updating sidebar date toLocaleString

### DIFF
--- a/client/src/view/components/sidebar/details/RoomDetails.spec.tsx
+++ b/client/src/view/components/sidebar/details/RoomDetails.spec.tsx
@@ -57,7 +57,7 @@ describe('Room specific detail widget', () => {
 
     expect(screen.getByText('#123-024')).toBeDefined();
     expect(screen.getByText('PopPop')).toBeDefined();
-    expect(screen.getByText('12/24/20')).toBeDefined();
+    expect(screen.getByText('12/24/2020, 12:00:00 AM')).toBeDefined();
   });
 
   it('renders our two buttons,', () => {

--- a/client/src/view/components/sidebar/details/RoomDetails.tsx
+++ b/client/src/view/components/sidebar/details/RoomDetails.tsx
@@ -45,16 +45,24 @@ const RoomDetails = (): JSX.Element => {
   const detailList = () => (
     <ul>
       {
-      rows.map((row) => (
-        <li
-          key={ row.value }
-        >
-          <DetailRow
-            name={ row.name }
-            value={ row.value }
-          />
-        </li>
-      ))
+      rows.map((row) => {
+        let dateVal = null;
+        if (row.name === 'Created at') {
+          const timeToShow = new Date(row.value);
+          dateVal = timeToShow.toLocaleString();
+        }
+
+        return (
+          <li
+            key={ row.value }
+          >
+            <DetailRow
+              name={ row.name }
+              value={ (dateVal || row.value) }
+            />
+          </li>
+        );
+      })
     }
     </ul>
   );

--- a/server/src/services/room-service.spec.ts
+++ b/server/src/services/room-service.spec.ts
@@ -169,7 +169,7 @@ describe('Room service', () => {
           },
           {
             name: 'Created at',
-            value: '7/9/2020, 8:26:30 PM',
+            value: 'Thu Jul 09 2020 20:26:30',
           },
           {
             name: 'Active Users',

--- a/server/src/services/room-service.ts
+++ b/server/src/services/room-service.ts
@@ -94,9 +94,6 @@ export default class RoomService {
       return removal;
     }
 
-    // Format date
-    const formatDate = new Date((updatedRoom as IRoom).createdAt);
-
     return [
       {
         name: 'ID',
@@ -108,7 +105,7 @@ export default class RoomService {
       },
       {
         name: 'Created at',
-        value: formatDate.toLocaleString(),
+        value: updatedRoom.createdAt,
       },
       {
         name: 'Active Users',


### PR DESCRIPTION
Moving the `toLocaleString` function from server to client. Unsurprisingly, converting it at the server just keeps the date in UTC and therefore isn't useful.

closes #140 